### PR TITLE
SL-6362 Add .maven.xml to jobqueue-sdk and remove archiva dist config

### DIFF
--- a/.maven.xml
+++ b/.maven.xml
@@ -1,0 +1,23 @@
+<settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/SETTINGS/1.0.0" xsi:schemalocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <!-- Maven Central Deployment -->
+      <id>ossrh</id>
+      <username>${env.SONATYPE_USERNAME}</username>
+      <password>${env.SONATYPE_PASSWORD}</password>
+    </server>
+  </servers>
+
+  <profiles>
+    <profile>
+      <id>ossrh</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <gpg.executable>${env.GPG_EXECUTABLE}</gpg.executable>
+        <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+      </properties>
+    </profile>
+  </profiles>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,16 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven.surefire.version}</version>
+                    <configuration>
+                        <argLine>
+                            -Dfile.encoding=UTF-8
+                            -javaagent:${settings.localRepository}/org/jmockit/jmockit/1.43/jmockit-1.43.jar
+                        </argLine>
+                        <excludes>
+                            <exclude>**/*IT.java</exclude>
+                            <exclude>**/*ITest.java</exclude>
+                        </excludes>
+                    </configuration>
                     <dependencies>
                         <dependency>
                             <groupId>org.apache.maven.surefire</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
                     <configuration>
                         <argLine>
                             -Dfile.encoding=UTF-8
-                            -javaagent:${settings.localRepository}/org/jmockit/jmockit/1.43/jmockit-1.43.jar
+                            -javaagent:${settings.localRepository}/org/jmockit/jmockit/1.38/jmockit-1.38.jar
                         </argLine>
                         <excludes>
                             <exclude>**/*IT.java</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -185,17 +185,4 @@
         </pluginManagement>
     </build>
 
-    <distributionManagement>
-      <repository>
-        <id>archiva.internal</id>
-        <name>Internal Release Repository</name>
-        <url>http://repo.ebx.sh/repository/internal/</url>
-      </repository>
-      <snapshotRepository>
-        <id>archiva.snapshots</id>
-        <name>Internal Snapshot Repository</name>
-        <url>http://repo.ebx.sh/repository/snapshots/</url>
-      </snapshotRepository>
-    </distributionManagement>
-
 </project>


### PR DESCRIPTION
## [SL-6362](https://echobox.atlassian.net/browse/SL-6362)

### Description of Changes
- Added `.maven.xml` file to project root
- Removed `<distributionManagement>` section from pom - this was for Archiva deployments
- Added jmockit configuration to maven-surefire-plugin 
### Documentation
N/A

### Risks & Impacts
None

### Security
No concerns

### Testing
To be tested in CircleCI pipelines

[SL-6362]: https://echobox.atlassian.net/browse/SL-6362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ