### PR TITLE
SL-5913 Pass required maven deployment plugins to JobQueue children

### DIFF
--- a/JobQueue/pom.xml
+++ b/JobQueue/pom.xml
@@ -65,6 +65,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
             </plugin>
+            <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/JobQueue/pom.xml
+++ b/JobQueue/pom.xml
@@ -66,8 +66,12 @@
                 <artifactId>maven-pmd-plugin</artifactId>
             </plugin>
             <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/JobQueueDemo/pom.xml
+++ b/JobQueueDemo/pom.xml
@@ -32,6 +32,14 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-gpg-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 	<profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,13 @@
         <junit.version>5.7.1</junit.version>
     </properties>
 
+    <developers>
+        <developer>
+        <name>Echobox</name>
+        <organizationUrl>http://www.echobox.com</organizationUrl>
+        </developer>
+    </developers>
+
     <modules>
         <module>JobQueue</module>
         <module>JobQueueDemo</module>


### PR DESCRIPTION
## [SL-5913](https://echobox.atlassian.net/browse/SL-5913)

### Description of Changes
Passes `nexus-staging-maven-plugin` and `maven-gpg-plugin` to JobQueue children. They will inherit the configuration from their parent

### Documentation
N/A

### Risks & Impacts
None

### Security
No concerns

### Testing
To be tested in Circle CI pipeline